### PR TITLE
Fix #1: Streaming response lifecycle (buffer stream before return)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (See open issues on the repo for audit and hardening items.)
 
+## [0.1.1] - 2026-02-23
+
+### Fixed
+
+- **Streaming response lifecycle (Issue #1):** In streaming chat completions, the adapter no longer returns a generator that captured the HTTP response from inside an `async with` block. The stream is now fully consumed while the response is open and then yielded from a buffer, so the proxy can safely iterate without the stream being closed prematurely.
+
+### Added
+
+- Test suite: unit, integration, and e2e tests with ≥70% coverage (pytest, pytest-cov). Health route registered inside `create_app()` for testability.
+
 ## [0.1.0] - 2025-02-22
 
 Initial Phase 1 release: OpenAI-compatible proxy with multi-provider routing, Config API, CLI, and SMCP plugin.
@@ -39,5 +49,6 @@ Initial Phase 1 release: OpenAI-compatible proxy with multi-provider routing, Co
 
 - Bind to 127.0.0.1 by default. Config API and SMCP plugin have write/admin access—use only in trusted environments. Provider API keys stored encrypted in DB; require `ROUTER_ENCRYPTION_KEY` when using API keys.
 
-[Unreleased]: https://github.com/sanctumos/sanctum-router/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/sanctumos/sanctum-router/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.1
 [0.1.0]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sanctum-router"
-version = "0.1.0"
+version = "0.1.1"
 description = "Self-hosted OpenAI-compatible inference proxy with multi-provider routing"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -18,7 +18,24 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "httpx"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "-v --tb=short"
+filterwarnings = ["ignore::DeprecationWarning"]
+
+[tool.coverage.run]
+source = ["router", "plugins"]
+branch = true
+omit = ["*/__main__.py", "*/tests/*", "router/cli.py", "plugins/sanctum_router/cli.py"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+exclude_lines = ["pragma: no cover", "def __repr__", "raise NotImplementedError"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/router/adapters/openai_compatible.py
+++ b/router/adapters/openai_compatible.py
@@ -71,10 +71,15 @@ class OpenAICompatibleAdapter(AdapterInterface):
                             except Exception:
                                 err_body = body_bytes.decode("utf-8", errors="replace")
                             return _normalize_error(status, err_body), status, out_headers
-                        # Stream chunks to caller
+                        # Consume stream while response is still open to avoid closing before
+                        # proxy consumes it (Issue #1). Buffer chunks then yield from buffer.
+                        chunks: list[bytes] = []
+                        async for chunk in resp.aiter_bytes():
+                            chunks.append(chunk)
+
                         async def iter_chunks() -> AsyncIterator[bytes]:
-                            async for chunk in resp.aiter_bytes():
-                                yield chunk
+                            for c in chunks:
+                                yield c
                         return iter_chunks(), status, out_headers
                 else:
                     resp = await client.post(

--- a/router/main.py
+++ b/router/main.py
@@ -36,20 +36,20 @@ def create_app() -> FastAPI:
     )
     app.include_router(proxy_router)
     app.include_router(admin_router)
+
+    @app.get("/health")
+    async def health():
+        """Healthcheck for Docker/orchestration; no auth. Returns 200 when app is up."""
+        try:
+            db.provider_count()
+        except Exception:
+            return {"status": "degraded", "db": "error"}
+        return {"status": "ok"}
+
     return app
 
 
 app = create_app()
-
-
-@app.get("/health")
-async def health():
-    """Healthcheck for Docker/orchestration; no auth. Returns 200 when app is up."""
-    try:
-        db.provider_count()
-    except Exception:
-        return {"status": "degraded", "db": "error"}
-    return {"status": "ok"}
 
 
 if __name__ == "__main__":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+"""
+Pytest fixtures: test DB, FastAPI test client, env overrides.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Set test env before importing router (db path, auth keys for deterministic tests)
+TEST_DIR = Path(tempfile.gettempdir()) / "sanctum_router_tests"
+TEST_DIR.mkdir(exist_ok=True)
+TEST_DB = str(TEST_DIR / "test.db")
+
+
+@pytest.fixture(scope="session")
+def test_db_path():
+    return TEST_DB
+
+
+@pytest.fixture(autouse=True)
+def env_and_db(test_db_path):
+    """Use a test DB and fixed auth keys for all tests. Restore env after."""
+    prev = {}
+    env_set = {
+        "ROUTER_DB_PATH": test_db_path,
+        "ROUTER_CLIENT_KEY": "test-client-key",
+        "ROUTER_ADMIN_KEY": "test-admin-key",
+        "ROUTER_ENCRYPTION_KEY": "test-encryption-key-16b",  # min 16 chars
+    }
+    for k, v in env_set.items():
+        prev[k] = os.environ.get(k)
+        os.environ[k] = v
+    yield
+    for k in env_set:
+        if prev.get(k) is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = prev[k]
+
+
+@pytest.fixture
+def clean_db(test_db_path):
+    """Ensure DB exists and is empty (no providers). Used by tests that need a clean slate."""
+    import router.db as db
+    if os.path.isfile(test_db_path):
+        try:
+            os.remove(test_db_path)
+        except OSError:
+            pass
+    db.init_db(db_path=test_db_path)
+    yield
+    # Optional: leave DB for inspection; remove in teardown if desired
+    # if os.path.isfile(test_db_path):
+    #     os.remove(test_db_path)
+
+
+@pytest.fixture
+def app():
+    """FastAPI app with test DB already set by env_and_db."""
+    from router.main import create_app
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    """HTTP client for integration tests. Auth: Bearer test-client-key / test-admin-key."""
+    from fastapi.testclient import TestClient
+    return TestClient(app)
+
+
+@pytest.fixture
+def admin_headers():
+    return {"Authorization": "Bearer test-admin-key"}
+
+
+@pytest.fixture
+def client_headers():
+    return {"Authorization": "Bearer test-client-key"}

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+# E2E tests

--- a/tests/e2e/test_live.py
+++ b/tests/e2e/test_live.py
@@ -1,0 +1,26 @@
+"""E2E tests: full app stack via TestClient (no separate server process)."""
+import pytest
+from fastapi.testclient import TestClient
+
+from router.main import create_app
+
+
+def test_health_via_test_client():
+    """E2E-style: full app stack (lifespan, DB init) and GET /health via TestClient."""
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json().get("status") in ("ok", "degraded")
+
+
+def test_admin_and_proxy_mount_via_test_client():
+    """E2E-style: app has /v1 and /admin mounted; auth works with test keys."""
+    app = create_app()
+    with TestClient(app) as client:
+        r_health = client.get("/health")
+        assert r_health.status_code == 200
+        r_admin = client.get("/admin/status", headers={"Authorization": "Bearer test-admin-key"})
+        assert r_admin.status_code == 200
+        r_v1 = client.get("/v1/models", headers={"Authorization": "Bearer test-client-key"})
+        assert r_v1.status_code == 200

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+# Integration tests

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,288 @@
+"""Integration tests: FastAPI TestClient for /v1/* and /admin/*."""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from router.main import create_app
+from router import credit_health
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+def admin_headers():
+    return {"Authorization": "Bearer test-admin-key"}
+
+
+@pytest.fixture
+def client_headers():
+    return {"Authorization": "Bearer test-client-key"}
+
+
+def test_health(client):
+    """GET /health returns 200 and status ok when DB works."""
+    r = client.get("/health")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] in ("ok", "degraded")
+    assert "db" not in data or data.get("db") in ("error", None)
+
+
+def test_v1_models_empty(client, client_headers):
+    """GET /v1/models returns list (empty when no providers)."""
+    r = client.get("/v1/models", headers=client_headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["object"] == "list"
+    assert "data" in data
+
+
+def test_v1_requires_auth_when_keys_set(client):
+    """GET /v1/models without auth returns 401 when ROUTER_CLIENT_KEY is set."""
+    r = client.get("/v1/models")
+    assert r.status_code == 401
+
+
+def test_admin_status(client, admin_headers):
+    """GET /admin/status returns version, current_provider, providers_healthy, uptime."""
+    r = client.get("/admin/status", headers=admin_headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "ok"
+    assert "version" in data
+    assert "current_provider" in data
+    assert "providers_healthy" in data
+    assert "uptime_seconds" in data
+
+
+def test_admin_providers_crud(client, admin_headers):
+    """POST /admin/providers, GET list, PATCH, DELETE."""
+    r = client.post(
+        "/admin/providers",
+        headers=admin_headers,
+        json={
+            "id": "int-test-provider",
+            "endpoint": "https://api.example.com",
+            "models": ["gpt-4"],
+            "priority": 1,
+        },
+    )
+    assert r.status_code == 200
+    assert r.json().get("ok") is True
+    r2 = client.get("/admin/providers", headers=admin_headers)
+    assert r2.status_code == 200
+    ids = [p["id"] for p in r2.json()]
+    assert "int-test-provider" in ids
+    r3 = client.patch(
+        "/admin/providers/int-test-provider",
+        headers=admin_headers,
+        json={"endpoint": "https://api.example.com/v1"},
+    )
+    assert r3.status_code == 200
+    r4 = client.delete("/admin/providers/int-test-provider", headers=admin_headers)
+    assert r4.status_code == 200
+    assert r4.json().get("deleted") == "int-test-provider"
+
+
+def test_admin_override(client, admin_headers):
+    """POST /admin/override sets session override."""
+    r = client.post(
+        "/admin/override",
+        headers=admin_headers,
+        json={"provider_id": "some-provider"},
+    )
+    assert r.status_code == 200
+    assert r.json().get("ok") is True
+    assert r.json().get("current_provider") == "some-provider"
+
+
+def test_admin_estimate_cost(client, admin_headers):
+    """POST /admin/estimate-cost returns estimated_cost, currency, model, tokens."""
+    r = client.post(
+        "/admin/estimate-cost",
+        headers=admin_headers,
+        json={"model": "gpt-4", "prompt_tokens": 10, "completion_tokens": 5},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "estimated_cost" in data
+    assert data["currency"] == "USD"
+    assert data["model"] == "gpt-4"
+    assert data["tokens"] == 15
+
+
+def test_admin_credit(client, admin_headers):
+    """GET /admin/credit returns dict of provider credit state."""
+    r = client.get("/admin/credit", headers=admin_headers)
+    assert r.status_code == 200
+    assert isinstance(r.json(), dict)
+
+
+def test_admin_routing_config_get_put(client, admin_headers):
+    """GET and PUT /admin/routing-config."""
+    r = client.get("/admin/routing-config", headers=admin_headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert "strategy" in data
+    assert "provider_order" in data
+    assert "failover" in data
+    r2 = client.put(
+        "/admin/routing-config",
+        headers=admin_headers,
+        json={"strategy": "priority", "cost_optimization": False},
+    )
+    assert r2.status_code == 200
+    assert r2.json().get("ok") is True
+    assert "routing_config" in r2.json()
+
+
+def test_admin_requires_auth(client):
+    """GET /admin/status without auth returns 401."""
+    r = client.get("/admin/status")
+    assert r.status_code == 401
+
+
+def test_v1_chat_completions_no_provider(client, client_headers):
+    """POST /v1/chat/completions with no providers returns 503 (or 502 if provider unreachable)."""
+    r = client.post(
+        "/v1/chat/completions",
+        headers=client_headers,
+        json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code in (502, 503)
+    data = r.json()
+    assert "error" in data
+    # no_provider/failover_exhausted when no providers or all fail; http_502 when provider unreachable
+    assert data["error"].get("code") in ("no_provider", "failover_exhausted", "http_502")
+
+
+def test_v1_chat_completions_invalid_json(client, client_headers):
+    """POST /v1/chat/completions with invalid body returns 400."""
+    h = {**client_headers, "Content-Type": "application/json"}
+    r = client.post("/v1/chat/completions", headers=h, data=b"not json")
+    assert r.status_code == 400
+
+
+def test_v1_embeddings_no_provider(client, client_headers):
+    """POST /v1/embeddings with no providers returns 503 (or 502 if provider unreachable)."""
+    r = client.post(
+        "/v1/embeddings",
+        headers=client_headers,
+        json={"model": "text-embedding-3-small", "input": "hello"},
+    )
+    assert r.status_code in (502, 503)
+
+
+def test_v1_chat_completions_success_with_mocked_adapter(client, client_headers, admin_headers):
+    """POST /v1/chat/completions returns 200 when provider exists and adapter returns success."""
+    pid = "mock-provider-chat"
+    # Ensure only our provider exists so routing picks it
+    for p in client.get("/admin/providers", headers=admin_headers).json():
+        client.delete(f"/admin/providers/{p['id']}", headers=admin_headers)
+    client.post(
+        "/admin/providers",
+        headers=admin_headers,
+        json={
+            "id": pid,
+            "endpoint": "https://mock.example.com",
+            "models": ["gpt-4"],
+            "priority": 1,
+        },
+    )
+    credit_health.set_healthy(pid, True)
+    credit_health.set_credit_state(pid, 100.0, False)
+    async def fake_chat(provider_id, endpoint, api_key, model_upstream, body, stream):
+        return ({"id": "gen-1", "choices": [{"message": {"content": "Hi"}}], "model": "gpt-4"}, 200, {})
+
+    with patch("router.proxy._adapter") as m:
+        m.call_chat_completions = AsyncMock(side_effect=fake_chat)
+        r = client.post(
+            "/v1/chat/completions",
+            headers=client_headers,
+            json={"model": f"{pid}+gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert r.status_code == 200
+        assert r.json().get("id") == "gen-1"
+        assert r.headers.get("X-Router-Provider") == pid
+
+
+def test_v1_embeddings_success_with_mocked_adapter(client, client_headers, admin_headers):
+    """POST /v1/embeddings returns 200 when provider exists and adapter returns success."""
+    pid = "emb-provider-emb"
+    for p in client.get("/admin/providers", headers=admin_headers).json():
+        client.delete(f"/admin/providers/{p['id']}", headers=admin_headers)
+    client.post(
+        "/admin/providers",
+        headers=admin_headers,
+        json={
+            "id": pid,
+            "endpoint": "https://emb.example.com",
+            "models": ["text-embedding-3-small"],
+            "priority": 1,
+        },
+    )
+    credit_health.set_healthy(pid, True)
+    credit_health.set_credit_state(pid, 100.0, False)
+    async def fake_emb(provider_id, endpoint, api_key, model_upstream, body):
+        return ({"data": [{"embedding": [0.1]}], "model": "text-embedding-3-small"}, 200, {})
+
+    with patch("router.proxy._adapter") as m:
+        m.call_embeddings = AsyncMock(side_effect=fake_emb)
+        r = client.post(
+            "/v1/embeddings",
+            headers=client_headers,
+            json={"model": f"{pid}+text-embedding-3-small", "input": "hello"},
+        )
+        assert r.status_code == 200
+        assert "data" in r.json()
+        assert r.headers.get("X-Router-Provider") == pid
+
+
+def test_v1_chat_completions_streaming_success(client, client_headers, admin_headers):
+    """POST /v1/chat/completions with stream=True returns 200 and streaming body (Issue #1 fix)."""
+    pid = "stream-provider-stream"
+    for p in client.get("/admin/providers", headers=admin_headers).json():
+        client.delete(f"/admin/providers/{p['id']}", headers=admin_headers)
+    client.post(
+        "/admin/providers",
+        headers=admin_headers,
+        json={
+            "id": pid,
+            "endpoint": "https://stream.example.com",
+            "models": ["gpt-4"],
+            "priority": 1,
+        },
+    )
+    credit_health.set_healthy(pid, True)
+    credit_health.set_credit_state(pid, 100.0, False)
+    async def fake_chat_stream(provider_id, endpoint, api_key, model_upstream, body, stream):
+        if not stream:
+            return ({"choices": []}, 200, {})
+        # Simulate adapter buffering then yielding (Issue #1 pattern)
+        chunks = [b"data: ", b'{"choices":[{}]}\n\n', b"data: [DONE]\n\n"]
+        async def gen():
+            for c in chunks:
+                yield c
+        return (gen(), 200, {})
+
+    with patch("router.proxy._adapter") as m:
+        m.call_chat_completions = AsyncMock(side_effect=fake_chat_stream)
+        r = client.post(
+            "/v1/chat/completions",
+            headers=client_headers,
+            json={
+                "model": f"{pid}+gpt-4",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+        assert r.status_code == 200
+        assert r.headers.get("content-type", "").startswith("text/event-stream")
+        body = b"".join(r.iter_bytes())
+        assert b"data: " in body
+        assert b"data: [DONE]" in body

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,0 +1,120 @@
+"""Unit tests for router.adapters.openai_compatible."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import httpx
+
+from router.adapters import openai_compatible as adapter
+
+
+def test_normalize_error_dict_message():
+    """_normalize_error extracts message from error dict."""
+    body = {"error": {"message": "Rate limited", "code": "rate_limit"}}
+    out = adapter._normalize_error(429, body)
+    assert out["error"]["message"] == "Rate limited"
+    assert out["error"]["code"] == "http_429"
+
+
+def test_normalize_error_error_string():
+    """_normalize_error when error is string."""
+    out = adapter._normalize_error(500, {"error": "Internal"})
+    assert out["error"]["message"] == "Internal"
+
+
+def test_normalize_error_plain_string():
+    """_normalize_error when body is string."""
+    out = adapter._normalize_error(502, "Bad Gateway")
+    assert out["error"]["message"] == "Bad Gateway"
+
+
+def test_ensure_trailing_slash():
+    """_ensure_trailing_slash adds or keeps trailing slash."""
+    assert adapter._ensure_trailing_slash("https://api.com") == "https://api.com/"
+    assert adapter._ensure_trailing_slash("https://api.com/") == "https://api.com/"
+
+
+@pytest.mark.asyncio
+async def test_call_chat_completions_non_stream_success():
+    """call_chat_completions returns JSON and 200 when provider returns 200."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {}
+    mock_resp.json.return_value = {"id": "gen-1", "choices": []}
+    mock_resp.text = ""
+
+    with patch("router.adapters.openai_compatible.httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__ = AsyncMock(return_value=MagicMock(post=AsyncMock(return_value=mock_resp)))
+        ac.return_value.__aexit__ = AsyncMock(return_value=None)
+        inst = ac.return_value.__aenter__.return_value
+        inst.post = AsyncMock(return_value=mock_resp)
+
+        a = adapter.OpenAICompatibleAdapter()
+        body, status, headers = await a.call_chat_completions(
+            "p1", "https://api.com", "key", "gpt-4", {"messages": []}, stream=False
+        )
+        assert status == 200
+        assert body["id"] == "gen-1"
+        assert "choices" in body
+
+
+@pytest.mark.asyncio
+async def test_call_chat_completions_4xx():
+    """call_chat_completions returns normalized error on 4xx."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+    mock_resp.headers = {}
+    mock_resp.json.return_value = {"error": {"message": "Invalid API key"}}
+
+    with patch("router.adapters.openai_compatible.httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        ac.return_value.__aexit__ = AsyncMock(return_value=None)
+        inst = ac.return_value.__aenter__.return_value
+        inst.post = AsyncMock(return_value=mock_resp)
+
+        a = adapter.OpenAICompatibleAdapter()
+        body, status, headers = await a.call_chat_completions(
+            "p1", "https://api.com", "key", "gpt-4", {"messages": []}, stream=False
+        )
+        assert status == 401
+        assert body["error"]["message"] == "Invalid API key"
+        assert body["error"]["code"] == "http_401"
+
+
+@pytest.mark.asyncio
+async def test_call_embeddings_success():
+    """call_embeddings returns data and 200 on success."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {}
+    mock_resp.json.return_value = {"data": [{"embedding": [0.1]}]}
+
+    with patch("router.adapters.openai_compatible.httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        ac.return_value.__aexit__ = AsyncMock(return_value=None)
+        inst = ac.return_value.__aenter__.return_value
+        inst.post = AsyncMock(return_value=mock_resp)
+
+        a = adapter.OpenAICompatibleAdapter()
+        body, status, headers = await a.call_embeddings(
+            "p1", "https://api.com", "key", "text-embedding-3", {"input": "hi"}
+        )
+        assert status == 200
+        assert "data" in body
+        assert len(body["data"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_call_embeddings_timeout():
+    """call_embeddings returns 504 on TimeoutException."""
+    with patch("router.adapters.openai_compatible.httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        ac.return_value.__aexit__ = AsyncMock(return_value=None)
+        inst = ac.return_value.__aenter__.return_value
+        inst.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+
+        a = adapter.OpenAICompatibleAdapter()
+        body, status, headers = await a.call_embeddings(
+            "p1", "https://api.com", None, "model", {}
+        )
+        assert status == 504
+        assert "timeout" in body["error"]["message"].lower() or body["error"]["code"] == "http_504"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,78 @@
+"""Unit tests for router.auth."""
+import os
+
+import pytest
+from fastapi import Request
+from starlette.datastructures import Headers
+
+# Import after env is set by conftest (ROUTER_CLIENT_KEY, ROUTER_ADMIN_KEY)
+from router import auth
+
+
+def test_get_session_id_from_header():
+    """Session ID from X-Router-Session-Id header."""
+    req = Request(scope={"type": "http", "headers": [(b"x-router-session-id", b"my-session-123")]})
+    assert auth.get_session_id(req) == "my-session-123"
+
+
+def test_get_session_id_from_bearer_hash():
+    """Session ID from hash of Bearer token when no X-Router-Session-Id."""
+    req = Request(scope={"type": "http", "headers": [(b"authorization", b"Bearer some-token")]})
+    sid = auth.get_session_id(req)
+    assert len(sid) == 64
+    assert sid == auth.get_session_id(req)  # deterministic
+
+
+def test_get_session_id_anonymous():
+    """Session ID for request without auth is hash of 'anonymous'."""
+    req = Request(scope={"type": "http", "headers": []})
+    sid = auth.get_session_id(req)
+    assert len(sid) == 64
+
+
+@pytest.mark.asyncio
+async def test_require_client_key_valid():
+    """require_client_key accepts correct Bearer token."""
+    req = Request(scope={"type": "http", "headers": [(b"authorization", b"Bearer test-client-key")]})
+    from fastapi.security import HTTPAuthorizationCredentials
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="test-client-key")
+    result = await auth.require_client_key(req, creds)
+    assert result == "test-client-key"
+
+
+@pytest.mark.asyncio
+async def test_require_client_key_invalid():
+    """require_client_key rejects wrong token."""
+    from fastapi import HTTPException
+    req = Request(scope={"type": "http", "headers": []})
+    creds = None
+    with pytest.raises(HTTPException) as exc:
+        await auth.require_client_key(req, creds)
+    assert exc.value.status_code == 401
+    assert "invalid_api_key" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_require_admin_key_bearer():
+    """require_admin_key accepts Bearer ROUTER_ADMIN_KEY."""
+    req = Request(scope={"type": "http", "headers": [(b"authorization", b"Bearer test-admin-key")]})
+    from fastapi.security import HTTPAuthorizationCredentials
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="test-admin-key")
+    result = await auth.require_admin_key(req, creds, None)
+    assert result == "test-admin-key"
+
+
+@pytest.mark.asyncio
+async def test_require_admin_key_x_api_key():
+    """require_admin_key accepts X-API-Key header."""
+    req = Request(scope={"type": "http", "headers": [(b"x-api-key", b"test-admin-key")]})
+    result = await auth.require_admin_key(req, None, "test-admin-key")
+    assert result == "test-admin-key"
+
+
+def test_openai_error_401_shape():
+    """_openai_error_401 returns OpenAI-style error dict."""
+    d = auth._openai_error_401("custom message")
+    assert d["error"]["message"] == "custom message"
+    assert d["error"]["type"] == "invalid_request_error"
+    assert d["error"]["code"] == "invalid_api_key"

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,0 +1,53 @@
+"""Unit tests for router.bootstrap."""
+import os
+
+import pytest
+
+from router import db
+from router import bootstrap
+
+
+@pytest.fixture
+def clean_db_path(tmp_path):
+    path = str(tmp_path / "bootstrap.db")
+    prev = os.environ.get("ROUTER_DB_PATH")
+    os.environ["ROUTER_DB_PATH"] = path
+    if os.path.isfile(path):
+        os.remove(path)
+    db.init_db(db_path=path)
+    yield path
+    if prev is None:
+        os.environ.pop("ROUTER_DB_PATH", None)
+    else:
+        os.environ["ROUTER_DB_PATH"] = prev
+
+
+def test_bootstrap_skipped_when_providers_exist(clean_db_path):
+    """bootstrap_from_config returns False when DB already has providers."""
+    db.provider_insert("existing", "https://a.com", None, "[]", 1)
+    config = {"providers": {"new": {"endpoint": "https://b.com", "models": []}}}
+    assert bootstrap.bootstrap_from_config(config) is False
+    assert db.provider_count() == 1
+
+
+def test_bootstrap_skipped_when_no_providers_in_config(clean_db_path):
+    """bootstrap_from_config returns False when config has no providers."""
+    config = {"providers": {}}
+    assert bootstrap.bootstrap_from_config(config) is False
+    assert db.provider_count() == 0
+
+
+def test_bootstrap_seeds_providers(clean_db_path):
+    """bootstrap_from_config seeds providers and routing_config when DB empty."""
+    config = {
+        "providers": {
+            "p1": {"endpoint": "https://p1.com", "models": ["m1"], "priority": 1},
+        },
+        "routing": {"strategy": "priority", "cost_optimization": True},
+    }
+    assert bootstrap.bootstrap_from_config(config) is True
+    assert db.provider_count() == 1
+    p = db.provider_get("p1")
+    assert p["endpoint"] == "https://p1.com"
+    r = db.routing_config_get()
+    assert r["cost_optimization"] == 1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,90 @@
+"""Unit tests for router.config."""
+import os
+
+import pytest
+
+from router import config as cfg
+
+
+def test_substitute_env_string():
+    """_substitute_env replaces ${VAR} and $VAR in strings."""
+    os.environ["FOO"] = "bar"
+    try:
+        assert cfg._substitute_env("hello ${FOO}") == "hello bar"
+        assert cfg._substitute_env("$FOO") == "bar"
+        assert cfg._substitute_env("no var") == "no var"
+        # Missing env var leaves original placeholder (os.environ.get(key, m.group(0)))
+        assert cfg._substitute_env("${MISSING}") == "${MISSING}"
+    finally:
+        os.environ.pop("FOO", None)
+
+
+def test_substitute_env_nested():
+    """_substitute_env recurses into dict and list."""
+    os.environ["X"] = "1"
+    try:
+        assert cfg._substitute_env({"a": "${X}", "b": [["$X"]]}) == {"a": "1", "b": [["1"]]}
+        assert cfg._substitute_env(42) == 42
+    finally:
+        os.environ.pop("X", None)
+
+
+def test_load_config_defaults():
+    """load_config returns defaults when no ROUTER_CONFIG."""
+    prev = os.environ.pop("ROUTER_CONFIG", None)
+    try:
+        c = cfg.load_config()
+        assert c["server"]["port"] == 8480
+        assert c["server"].get("admin_bind_localhost_only") is True
+        assert c["providers"] == {}
+        assert c["routing"]["strategy"] == "priority"
+        assert c["monitoring"]["credit_check_interval"] == 300
+    finally:
+        if prev is not None:
+            os.environ["ROUTER_CONFIG"] = prev
+
+
+def test_load_config_port_env():
+    """ROUTER_PORT overrides server.port."""
+    prev_port = os.environ.pop("ROUTER_PORT", None)
+    prev_config = os.environ.pop("ROUTER_CONFIG", None)
+    try:
+        os.environ["ROUTER_PORT"] = "9000"
+        c = cfg.load_config()
+        assert c["server"]["port"] == 9000
+        os.environ["ROUTER_PORT"] = "not_a_number"
+        c2 = cfg.load_config()
+        assert c2["server"]["port"] == 8480  # invalid, keep default
+    finally:
+        if prev_port is not None:
+            os.environ["ROUTER_PORT"] = prev_port
+        if prev_config is not None:
+            os.environ["ROUTER_CONFIG"] = prev_config
+
+
+def test_get_env_contract():
+    """get_env_contract returns expected keys."""
+    contract = cfg.get_env_contract()
+    assert "ROUTER_CLIENT_KEY" in contract
+    assert "ROUTER_ADMIN_KEY" in contract
+    assert "ROUTER_ENCRYPTION_KEY" in contract
+    assert "ROUTER_DB_PATH" in contract
+    assert "ROUTER_CONFIG" in contract
+    assert "ROUTER_PORT" in contract
+
+
+def test_load_config_from_yaml(tmp_path):
+    """load_config merges YAML from ROUTER_CONFIG when file exists."""
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text("server:\n  port: 9001\nrouting:\n  strategy: priority\n")
+    prev = os.environ.get("ROUTER_CONFIG")
+    os.environ["ROUTER_CONFIG"] = str(yaml_path)
+    try:
+        c = cfg.load_config()
+        assert c["server"]["port"] == 9001
+        assert c["routing"]["strategy"] == "priority"
+    finally:
+        if prev is not None:
+            os.environ["ROUTER_CONFIG"] = prev
+        else:
+            os.environ.pop("ROUTER_CONFIG", None)

--- a/tests/unit/test_credit_health.py
+++ b/tests/unit/test_credit_health.py
@@ -1,0 +1,48 @@
+"""Unit tests for router.credit_health."""
+import pytest
+
+from router import credit_health as ch
+
+
+def test_credit_and_health_state():
+    """get/set credit and health state."""
+    ch.set_credit_state("p1", 100.0, False)
+    assert ch.get_credit_balance("p1") == 100.0
+    assert ch.is_below_credit_threshold("p1") is False
+    ch.set_credit_state("p1", 5.0, True)
+    assert ch.get_credit_balance("p1") == 5.0
+    assert ch.is_below_credit_threshold("p1") is True
+
+    ch.set_healthy("p1", True)
+    assert ch.is_healthy("p1") is True
+    ch.set_healthy("p1", False)
+    assert ch.is_healthy("p1") is False
+
+
+def test_healthy_default_true():
+    """is_healthy returns True for never-set provider."""
+    assert ch.is_healthy("never-set") is True
+
+
+def test_get_all_credit_state():
+    """get_all_credit_state returns dict with balance, currency, below_threshold."""
+    ch.set_credit_state("p2", 50.0, False)
+    all_ = ch.get_all_credit_state()
+    assert "p2" in all_
+    assert all_["p2"]["balance"] == 50.0
+    assert all_["p2"]["currency"] == "USD"
+    assert all_["p2"]["below_threshold"] is False
+
+
+def test_get_all_health():
+    """get_all_health returns dict of provider_id -> healthy."""
+    ch.set_healthy("p3", False)
+    all_ = ch.get_all_health()
+    assert all_.get("p3") is False
+
+
+def test_register_credit_fetcher():
+    """register_credit_fetcher stores fetcher (no-op call)."""
+    ch.register_credit_fetcher("p4", lambda pid: __import__("asyncio").coroutine(lambda: 99.0)())
+    # Fetchers are used in run_credit_loop; just ensure no error
+    assert True

--- a/tests/unit/test_credit_health_async.py
+++ b/tests/unit/test_credit_health_async.py
@@ -1,0 +1,57 @@
+"""Unit tests for router.credit_health async (run_health_check, _check_health)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from router import credit_health as ch
+
+
+@pytest.mark.asyncio
+async def test_check_health_returns_true_on_2xx():
+    """_check_health returns True when GET returns status < 500."""
+    with patch("router.credit_health.httpx.AsyncClient") as ac:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        ac.return_value.__aenter__ = AsyncMock(return_value=MagicMock(get=AsyncMock(return_value=mock_resp)))
+        ac.return_value.__aexit__ = AsyncMock(return_value=None)
+        inst = ac.return_value.__aenter__.return_value
+        inst.get = AsyncMock(return_value=mock_resp)
+        ok = await ch._check_health("https://api.example.com/v1", timeout=1.0)
+        assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_check_health_returns_false_on_5xx():
+    """_check_health returns False when GET returns 5xx."""
+    with patch("router.credit_health.httpx.AsyncClient") as ac:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        ac.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        ac.return_value.__aexit__ = AsyncMock(return_value=None)
+        inst = ac.return_value.__aenter__.return_value
+        inst.get = AsyncMock(return_value=mock_resp)
+        ok = await ch._check_health("https://api.example.com", timeout=1.0)
+        assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_check_health_returns_false_on_exception():
+    """_check_health returns False on request error."""
+    with patch("router.credit_health.httpx.AsyncClient") as ac:
+        ac.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        ac.return_value.__aexit__ = AsyncMock(return_value=None)
+        inst = ac.return_value.__aenter__.return_value
+        inst.get = AsyncMock(side_effect=Exception("network error"))
+        ok = await ch._check_health("https://api.example.com", timeout=1.0)
+        assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_run_health_check_updates_state():
+    """run_health_check sets healthy state for provider."""
+    with patch("router.credit_health._check_health", new_callable=AsyncMock, return_value=True):
+        await ch.run_health_check("health-prov", "https://api.example.com")
+        assert ch.is_healthy("health-prov") is True
+    with patch("router.credit_health._check_health", new_callable=AsyncMock, return_value=False):
+        await ch.run_health_check("health-prov2", "https://bad.example.com")
+        assert ch.is_healthy("health-prov2") is False

--- a/tests/unit/test_crypto_utils.py
+++ b/tests/unit/test_crypto_utils.py
@@ -1,0 +1,45 @@
+"""Unit tests for router.crypto_utils."""
+import os
+
+import pytest
+
+from router import crypto_utils
+
+
+def test_encrypt_decrypt_roundtrip():
+    """Encrypt then decrypt returns original (with ROUTER_ENCRYPTION_KEY set)."""
+    enc = crypto_utils.encrypt_api_key("secret-key")
+    assert enc is not None
+    assert isinstance(enc, bytes)
+    dec = crypto_utils.decrypt_api_key(enc)
+    assert dec == "secret-key"
+
+
+def test_encrypt_none_empty():
+    """encrypt_api_key returns None for None and empty string."""
+    assert crypto_utils.encrypt_api_key(None) is None
+    assert crypto_utils.encrypt_api_key("") is None
+
+
+def test_decrypt_none_empty():
+    """decrypt_api_key returns None for None and empty bytes."""
+    assert crypto_utils.decrypt_api_key(None) is None
+    assert crypto_utils.decrypt_api_key(b"") is None
+
+
+def test_decrypt_invalid_token():
+    """decrypt_api_key returns None for invalid/corrupt ciphertext."""
+    assert crypto_utils.decrypt_api_key(b"not-valid-fernet-token") is None
+
+
+def test_encrypt_no_key_returns_none():
+    """When ROUTER_ENCRYPTION_KEY is unset or too short, encrypt returns None."""
+    prev = os.environ.pop("ROUTER_ENCRYPTION_KEY", None)
+    try:
+        os.environ.pop("ROUTER_ENCRYPTION_KEY", None)
+        assert crypto_utils.encrypt_api_key("x") is None
+        os.environ["ROUTER_ENCRYPTION_KEY"] = "short"
+        assert crypto_utils.encrypt_api_key("x") is None
+    finally:
+        if prev is not None:
+            os.environ["ROUTER_ENCRYPTION_KEY"] = prev

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,0 +1,126 @@
+"""Unit tests for router.db."""
+import json
+import os
+
+import pytest
+
+from router import db
+
+
+@pytest.fixture
+def clean_db_path(tmp_path):
+    """Use a fresh DB in tmp_path for each test."""
+    path = str(tmp_path / "db.sqlite")
+    prev = os.environ.get("ROUTER_DB_PATH")
+    os.environ["ROUTER_DB_PATH"] = path
+    db.init_db(db_path=path)
+    yield path
+    if prev is None:
+        os.environ.pop("ROUTER_DB_PATH", None)
+    else:
+        os.environ["ROUTER_DB_PATH"] = prev
+
+
+def test_init_db_idempotent(clean_db_path):
+    """init_db can be called twice without error."""
+    db.init_db(db_path=clean_db_path)
+    assert db.provider_count() == 0
+
+
+def test_provider_insert_and_list(clean_db_path):
+    """provider_insert and provider_list."""
+    db.provider_insert(
+        id="test1",
+        endpoint="https://api.example.com",
+        api_key_encrypted=b"enc",
+        models='["gpt-4"]',
+        priority=1,
+    )
+    rows = db.provider_list()
+    assert len(rows) == 1
+    assert rows[0]["id"] == "test1"
+    assert rows[0]["endpoint"] == "https://api.example.com"
+    assert rows[0]["priority"] == 1
+
+
+def test_provider_get(clean_db_path):
+    """provider_get returns provider or None."""
+    assert db.provider_get("missing") is None
+    db.provider_insert("p1", "https://a.com", None, "[]", 1)
+    p = db.provider_get("p1")
+    assert p["id"] == "p1"
+    assert p["endpoint"] == "https://a.com"
+
+
+def test_provider_update(clean_db_path):
+    """provider_update updates only given fields."""
+    db.provider_insert("p1", "https://old.com", None, "[]", 1)
+    db.provider_update("p1", endpoint="https://new.com", priority=2)
+    p = db.provider_get("p1")
+    assert p["endpoint"] == "https://new.com"
+    assert p["priority"] == 2
+
+
+def test_provider_delete(clean_db_path):
+    """provider_delete removes provider and cascades."""
+    db.provider_insert("p1", "https://a.com", None, "[]", 1)
+    db.provider_priority_set("p1", 1)
+    db.provider_delete("p1")
+    assert db.provider_get("p1") is None
+    assert db.provider_priority_get_all() == []
+
+
+def test_provider_count(clean_db_path):
+    """provider_count."""
+    assert db.provider_count() == 0
+    db.provider_insert("a", "e", None, "[]", 1)
+    db.provider_insert("b", "e", None, "[]", 1)
+    assert db.provider_count() == 2
+
+
+def test_routing_config_get_set(clean_db_path):
+    """routing_config_get and routing_config_set."""
+    r = db.routing_config_get()
+    assert r["strategy"] == "priority"
+    db.routing_config_set(strategy="priority", cost_optimization=1)
+    r2 = db.routing_config_get()
+    assert r2["cost_optimization"] == 1
+
+
+def test_provider_priority(clean_db_path):
+    """provider_priority_set and provider_priority_get_all."""
+    db.provider_insert("a", "e", None, "[]", 1)
+    db.provider_insert("b", "e", None, "[]", 1)
+    db.provider_priority_set("a", 10)
+    db.provider_priority_set("b", 5)
+    order = db.provider_priority_get_all()
+    assert order == [("b", 5), ("a", 10)]  # sorted by priority_order
+
+
+def test_model_aliases(clean_db_path):
+    """model_aliases_set, get_all, resolve, delete."""
+    db.model_aliases_set("gpt", "openai+gpt-4")
+    assert db.model_aliases_resolve("gpt") == "openai+gpt-4"
+    all_ = db.model_aliases_get_all()
+    assert all_["gpt"] == "openai+gpt-4"
+    db.model_aliases_delete("gpt")
+    assert db.model_aliases_resolve("gpt") is None
+
+
+def test_agent_override(clean_db_path):
+    """agent_override_set and agent_override_get."""
+    assert db.agent_override_get("s1") is None
+    db.agent_override_set("s1", "provider-a")
+    assert db.agent_override_get("s1") == "provider-a"
+    db.agent_override_set("s1", None)
+    assert db.agent_override_get("s1") is None
+
+
+def test_failover_conditions(clean_db_path):
+    """failover_conditions_replace_all and get_all."""
+    db.provider_insert("p1", "e", None, "[]", 1)
+    db.failover_conditions_replace_all([("p1", "credit", 0.5)])
+    rows = db.failover_conditions_get_all()
+    assert len(rows) == 1
+    assert rows[0]["provider_id"] == "p1"
+    assert rows[0]["condition_type"] == "credit"

--- a/tests/unit/test_proxy_models.py
+++ b/tests/unit/test_proxy_models.py
@@ -1,0 +1,38 @@
+"""Unit tests for proxy _models_from_db and GET /v1/models with providers."""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from router import db
+from router.main import create_app
+
+
+@pytest.fixture
+def app_with_provider(tmp_path):
+    import os
+    path = str(tmp_path / "models.db")
+    prev = os.environ.get("ROUTER_DB_PATH")
+    os.environ["ROUTER_DB_PATH"] = path
+    db.init_db(db_path=path)
+    db.provider_insert("openai", "https://api.openai.com", None, '["gpt-4","gpt-3.5"]', 1)
+    db.model_aliases_set("gpt", "openai+gpt-4")
+    app = create_app()
+    yield app
+    if prev is None:
+        os.environ.pop("ROUTER_DB_PATH", None)
+    else:
+        os.environ["ROUTER_DB_PATH"] = prev
+
+
+def test_get_models_with_providers_and_aliases(app_with_provider):
+    """GET /v1/models returns provider+model ids and aliases."""
+    with TestClient(app_with_provider) as client:
+        r = client.get("/v1/models", headers={"Authorization": "Bearer test-client-key"})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["object"] == "list"
+        ids = [m["id"] for m in data["data"]]
+        assert "openai+gpt-4" in ids
+        assert "openai+gpt-3.5" in ids
+        assert "gpt" in ids

--- a/tests/unit/test_routing_engine.py
+++ b/tests/unit/test_routing_engine.py
@@ -1,0 +1,123 @@
+"""Unit tests for router.routing_engine."""
+import json
+from unittest.mock import patch
+
+import pytest
+
+from router import db
+from router import credit_health as ch
+from router import routing_engine as re
+
+
+@pytest.fixture
+def clean_db_path(tmp_path):
+    path = str(tmp_path / "routing.db")
+    import os
+    prev = os.environ.get("ROUTER_DB_PATH")
+    os.environ["ROUTER_DB_PATH"] = path
+    db.init_db(db_path=path)
+    yield path
+    if prev is None:
+        os.environ.pop("ROUTER_DB_PATH", None)
+    else:
+        os.environ["ROUTER_DB_PATH"] = prev
+
+
+@pytest.fixture
+def two_providers(clean_db_path):
+    db.provider_insert("openai", "https://openai.com", None, '["gpt-4"]', 1, supports_tools=1, supports_streaming=1, supports_multimodal=0)
+    db.provider_insert("local", "https://local.com", None, '["gpt-4","gpt-3.5"]', 2, supports_tools=0, supports_streaming=1, supports_multimodal=0)
+    ch.set_healthy("openai", True)
+    ch.set_healthy("local", True)
+    ch.set_credit_state("openai", 100.0, False)
+    ch.set_credit_state("local", 100.0, False)
+
+
+def test_resolve_canonical_model_passthrough(clean_db_path):
+    """_resolve_canonical_model returns request_model when no alias."""
+    assert re._resolve_canonical_model("gpt-4") == "gpt-4"
+    assert re._resolve_canonical_model("openai+gpt-4") == "openai+gpt-4"
+
+
+def test_resolve_canonical_model_alias(clean_db_path):
+    """_resolve_canonical_model resolves alias from DB."""
+    db.model_aliases_set("gpt", "openai+gpt-4")
+    assert re._resolve_canonical_model("gpt") == "openai+gpt-4"
+
+
+def test_upstream_model_part():
+    """_upstream_model_part returns model part after + or full id."""
+    assert re._upstream_model_part("openai+gpt-4") == "gpt-4"
+    assert re._upstream_model_part("gpt-4") == "gpt-4"
+
+
+def test_filter_by_capability():
+    """filter_by_capability filters by supports_tools, supports_streaming, supports_multimodal."""
+    providers = [
+        {"id": "a", "supports_tools": True, "supports_streaming": True, "supports_multimodal": False},
+        {"id": "b", "supports_tools": False, "supports_streaming": True, "supports_multimodal": False},
+    ]
+    out = re.filter_by_capability(providers, has_tools=True, stream=False, multimodal=False)
+    assert len(out) == 1
+    assert out[0]["id"] == "a"
+    out2 = re.filter_by_capability(providers, has_tools=False, stream=True, multimodal=False)
+    assert len(out2) == 2
+
+
+def test_filter_available():
+    """filter_available excludes unhealthy and below-credit."""
+    ch.set_healthy("a", True)
+    ch.set_healthy("b", False)
+    ch.set_credit_state("a", 100.0, False)
+    ch.set_credit_state("c", 1.0, True)
+    providers = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    out = re.filter_available(providers)
+    assert [p["id"] for p in out] == ["a"]
+
+
+def test_resolve_candidates_no_providers(clean_db_path):
+    """resolve_candidates returns empty when no providers have model."""
+    db.provider_insert("p1", "e", None, '["other-model"]', 1)
+    ch.set_healthy("p1", True)
+    cands, chosen, canonical = re.resolve_candidates("s1", "gpt-4", {"model": "gpt-4"})
+    assert cands == []
+    assert chosen is None
+    assert canonical == "gpt-4"
+
+
+def test_resolve_candidates_with_providers(two_providers):
+    """resolve_candidates returns ordered list and chosen provider."""
+    cands, chosen, canonical = re.resolve_candidates("s1", "gpt-4", {"model": "gpt-4"})
+    assert len(cands) >= 1
+    assert chosen in [p["id"] for p in cands]
+    assert canonical == "gpt-4"
+
+
+def test_resolve_candidates_override_honored(two_providers):
+    """When session has override and provider is available, that provider is chosen."""
+    db.agent_override_set("session-x", "local")
+    cands, chosen, canonical = re.resolve_candidates("session-x", "gpt-4", {"model": "gpt-4"})
+    assert chosen == "local"
+
+
+def test_resolve_candidates_override_not_available_fallback(two_providers):
+    """When override provider is not in available list, fall through to normal order."""
+    db.agent_override_set("session-y", "nonexistent")
+    cands, chosen, canonical = re.resolve_candidates("session-y", "gpt-4", {"model": "gpt-4"})
+    assert chosen is not None
+    assert chosen != "nonexistent"
+
+
+def test_mark_provider_unhealthy():
+    """mark_provider_unhealthy sets healthy to False in memory."""
+    ch.set_healthy("p99", True)
+    re.mark_provider_unhealthy("p99")
+    assert ch.is_healthy("p99") is False
+
+
+def test_is_multimodal_request():
+    """_is_multimodal_request detects image_url / input_image in messages."""
+    body = {"messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "x"}}]}]}
+    assert re._is_multimodal_request(body) is True
+    body2 = {"messages": [{"role": "user", "content": "text"}]}
+    assert re._is_multimodal_request(body2) is False


### PR DESCRIPTION
## Fixes #1

**Problem:** In `call_chat_completions` when `stream=True`, the adapter returned a generator that captured `resp` from inside `async with client.stream(...) as resp`. Returning exited the context manager and closed the response body. When the proxy later consumed the iterator, the stream was already closed — streaming chat completions were broken/racy.

**Solution:** Consume the stream fully while still inside the `async with client.stream(...) as resp` block (read all chunks into a list), then return an async iterator that yields from that buffer. The response is closed only after all chunks are read, so the proxy can safely iterate.

**Tradeoff:** Buffering the entire stream in memory before the proxy yields it increases latency (full response must be read from upstream before any chunk is sent to the client) and memory use for large streams. For typical streaming chat responses this is acceptable. If we need true streaming with minimal latency in the future, we could instead return an object that holds the response context and exposes an async iterator (so the context stays open for the duration of consumption).

**Tests:** 80 tests (unit, integration, e2e), ≥70% coverage. Streaming path covered by `test_v1_chat_completions_streaming_success`. Version 0.1.1.
