### PR TITLE
Fix #2, #4: Require ROUTER_ENCRYPTION_KEY; constant-time auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (See open issues on the repo for audit and hardening items.)
 
+## [0.1.2] - 2026-02-23
+
+### Fixed
+
+- **Issue #2:** Require `ROUTER_ENCRYPTION_KEY` when storing provider API keys. Admin create/patch return 400 with a clear message if key is missing or too short; bootstrap raises at startup instead of silently storing NULL.
+- **Issue #4:** Use constant-time comparison (`hmac.compare_digest`) for client and admin token auth to avoid timing side channels.
+
+### Added
+
+- `crypto_utils.encryption_available()` to check if encryption key is set. Integration test for create_provider when encryption unavailable.
+
 ## [0.1.1] - 2026-02-23
 
 ### Fixed
@@ -49,6 +60,7 @@ Initial Phase 1 release: OpenAI-compatible proxy with multi-provider routing, Co
 
 - Bind to 127.0.0.1 by default. Config API and SMCP plugin have write/admin access—use only in trusted environments. Provider API keys stored encrypted in DB; require `ROUTER_ENCRYPTION_KEY` when using API keys.
 
-[Unreleased]: https://github.com/sanctumos/sanctum-router/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/sanctumos/sanctum-router/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.2
 [0.1.1]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.1
 [0.1.0]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sanctum-router"
-version = "0.1.1"
+version = "0.1.2"
 description = "Self-hosted OpenAI-compatible inference proxy with multi-provider routing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/router/admin.py
+++ b/router/admin.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from router import __version__, db
 from router.auth import get_session_id, require_admin_key
-from router.crypto_utils import encrypt_api_key
+from router.crypto_utils import encrypt_api_key, encryption_available
 from router.credit_health import get_all_credit_state, get_all_health
 
 router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(require_admin_key)])
@@ -78,6 +78,11 @@ class ProviderCreate(BaseModel):
 async def create_provider(p: ProviderCreate):
     """POST /admin/providers — allowed fields include supports_multimodal; encrypt api_key. Returns { ok, provider } per PRD."""
     models_str = p.models if isinstance(p.models, str) else json.dumps(p.models)
+    if p.api_key and not encryption_available():
+        raise HTTPException(
+            status_code=400,
+            detail="ROUTER_ENCRYPTION_KEY is required to store provider API keys. Set it (min 16 characters) and retry.",
+        )
     enc = encrypt_api_key(p.api_key) if p.api_key else None
     db.provider_insert(
         id=p.id,
@@ -138,6 +143,11 @@ async def update_provider(provider_id: str, p: ProviderPatch):
     if p.supports_multimodal is not None:
         kwargs["supports_multimodal"] = 1 if p.supports_multimodal else 0
     if p.api_key is not None:
+        if p.api_key and not encryption_available():
+            raise HTTPException(
+                status_code=400,
+                detail="ROUTER_ENCRYPTION_KEY is required to store provider API keys. Set it (min 16 characters) and retry.",
+            )
         kwargs["api_key_encrypted"] = encrypt_api_key(p.api_key)
     if kwargs:
         db.provider_update(provider_id, **kwargs)

--- a/router/auth.py
+++ b/router/auth.py
@@ -6,6 +6,7 @@ Authentication and session correlation. PRD § Config API, §6 Config API.
 """
 
 import hashlib
+import hmac
 import os
 from typing import Optional
 
@@ -45,7 +46,7 @@ async def require_client_key(
     token = None
     if credentials:
         token = credentials.credentials
-    if token != CLIENT_KEY:
+    if not hmac.compare_digest((token or "").encode("utf-8"), CLIENT_KEY.encode("utf-8")):
         raise HTTPException(status_code=401, detail=_openai_error_401())
     return token
 
@@ -63,9 +64,9 @@ async def require_admin_key(
     token = None
     if credentials:
         token = credentials.credentials
-    if api_key and api_key == ADMIN_KEY:
+    if api_key and hmac.compare_digest(api_key.encode("utf-8"), ADMIN_KEY.encode("utf-8")):
         token = api_key
-    if token != ADMIN_KEY:
+    if not hmac.compare_digest((token or "").encode("utf-8"), ADMIN_KEY.encode("utf-8")):
         raise HTTPException(status_code=401, detail=_openai_error_401())
     return token
 

--- a/router/bootstrap.py
+++ b/router/bootstrap.py
@@ -7,7 +7,7 @@ import json
 import os
 from typing import Any
 
-from router.crypto_utils import encrypt_api_key
+from router.crypto_utils import encrypt_api_key, encryption_available
 from router import db
 
 
@@ -35,6 +35,11 @@ def bootstrap_from_config(config: dict[str, Any]) -> bool:
         if isinstance(api_key, str) and api_key.startswith("${") and api_key.endswith("}"):
             key = api_key[2:-1].strip()
             api_key = os.environ.get(key, "")
+        if api_key and not encryption_available():
+            raise RuntimeError(
+                "ROUTER_ENCRYPTION_KEY is required to store provider API keys in bootstrap. "
+                "Set it (min 16 characters) before starting the router."
+            )
         encrypted = encrypt_api_key(api_key) if api_key else None
         models = p.get("models", [])
         models_str = models if isinstance(models, str) else json.dumps(models)

--- a/router/crypto_utils.py
+++ b/router/crypto_utils.py
@@ -22,6 +22,11 @@ def _get_encryption_key() -> Optional[bytes]:
     return base64.urlsafe_b64encode(kdf.derive(raw.encode("utf-8") if isinstance(raw, str) else raw))
 
 
+def encryption_available() -> bool:
+    """Return True if ROUTER_ENCRYPTION_KEY is set and valid (min 16 chars). Use before storing API keys."""
+    return _get_encryption_key() is not None
+
+
 def encrypt_api_key(plaintext: Optional[str]) -> Optional[bytes]:
     if plaintext is None or plaintext == "":
         return None

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -60,6 +60,24 @@ def test_admin_status(client, admin_headers):
     assert "uptime_seconds" in data
 
 
+def test_admin_create_provider_requires_encryption_key(client, admin_headers):
+    """POST /admin/providers with api_key when encryption unavailable returns 400 (Issue #2)."""
+    with patch("router.admin.encryption_available", return_value=False):
+        r = client.post(
+            "/admin/providers",
+            headers=admin_headers,
+            json={
+                "id": "need-encryption",
+                "endpoint": "https://api.example.com",
+                "models": ["gpt-4"],
+                "priority": 1,
+                "api_key": "secret",
+            },
+        )
+    assert r.status_code == 400
+    assert "ROUTER_ENCRYPTION_KEY" in r.json().get("detail", "")
+
+
 def test_admin_providers_crud(client, admin_headers):
     """POST /admin/providers, GET list, PATCH, DELETE."""
     r = client.post(

--- a/tests/unit/test_crypto_utils.py
+++ b/tests/unit/test_crypto_utils.py
@@ -43,3 +43,18 @@ def test_encrypt_no_key_returns_none():
     finally:
         if prev is not None:
             os.environ["ROUTER_ENCRYPTION_KEY"] = prev
+
+
+def test_encryption_available():
+    """encryption_available returns True when key set and long enough, False otherwise."""
+    prev = os.environ.pop("ROUTER_ENCRYPTION_KEY", None)
+    try:
+        os.environ.pop("ROUTER_ENCRYPTION_KEY", None)
+        assert crypto_utils.encryption_available() is False
+        os.environ["ROUTER_ENCRYPTION_KEY"] = "short"
+        assert crypto_utils.encryption_available() is False
+        os.environ["ROUTER_ENCRYPTION_KEY"] = "test-encryption-key-16b"
+        assert crypto_utils.encryption_available() is True
+    finally:
+        if prev is not None:
+            os.environ["ROUTER_ENCRYPTION_KEY"] = prev


### PR DESCRIPTION
## Fixes #2, #4 (Group 1 – Security)

**#2 – Require ROUTER_ENCRYPTION_KEY when storing provider API keys**
- Added `crypto_utils.encryption_available()`.
- Admin create_provider: if request includes api_key and encryption not available → 400 with clear message.
- Admin update_provider: same when api_key is provided (non-empty).
- Bootstrap: if any provider has api_key and encryption not available → RuntimeError at startup (fail loudly).

**#4 – Constant-time comparison for client/admin token auth**
- Replaced `!=` with `hmac.compare_digest` in require_client_key and require_admin_key.

Tests: 82 passed, coverage ≥70%. Version 0.1.2.
