### PR TITLE
Fix #15,#18,#19,#20: try_candidates, routing API, failover doc, override comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (See open issues on the repo for audit and hardening items.)
 
+## [0.1.5] - 2026-02-23
+
+### Changed
+
+- **#15:** Extract generic `_try_candidates` in proxy; chat and embeddings use it with adapter callbacks. Reduces duplication.
+- **#18:** Routing engine: `resolve_canonical_model` and `upstream_model_part` are now public API (renamed from _prefix). Improved type hints.
+- **#19:** Document in routing_engine that failover_conditions are persisted for API consistency and future use; engine uses in-memory health and credit_threshold only.
+- **#20:** Comment in resolve_candidates: override honored only when provider is in the available set.
+
 ## [0.1.4] - 2026-02-23
 
 ### Fixed / Documentation
@@ -78,7 +87,8 @@ Initial Phase 1 release: OpenAI-compatible proxy with multi-provider routing, Co
 
 - Bind to 127.0.0.1 by default. Config API and SMCP plugin have write/admin access—use only in trusted environments. Provider API keys stored encrypted in DB; require `ROUTER_ENCRYPTION_KEY` when using API keys.
 
-[Unreleased]: https://github.com/sanctumos/sanctum-router/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/sanctumos/sanctum-router/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.5
 [0.1.4]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.4
 [0.1.3]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.3
 [0.1.2]: https://github.com/sanctumos/sanctum-router/releases/tag/v0.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sanctum-router"
-version = "0.1.4"
+version = "0.1.5"
 description = "Self-hosted OpenAI-compatible inference proxy with multi-provider routing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/router/proxy.py
+++ b/router/proxy.py
@@ -14,9 +14,9 @@ from router import db
 from router.routing_engine import (
     resolve_candidates,
     mark_provider_unhealthy,
-    _upstream_model_part,
+    upstream_model_part,
+    resolve_canonical_model,
 )
-from router.routing_engine import _resolve_canonical_model
 
 router = APIRouter(prefix="/v1", tags=["proxy"], dependencies=[Depends(require_client_key)])
 
@@ -60,20 +60,24 @@ def _get_provider(provider_id: str) -> dict | None:
     return db.provider_get(provider_id)
 
 
-async def _try_chat_completions(
-    body: dict, session_id: str, canonical_model: str
+async def _try_candidates(
+    body: dict,
+    session_id: str,
+    canonical_model: str,
+    no_provider_code: str,
+    adapter_call: Any,
 ) -> tuple[Any, int, dict[str, str], str | None]:
-    """Try candidates in order; return (body_or_stream, status, headers, chosen_provider_id)."""
+    """Generic try-candidates loop. adapter_call(pid, endpoint, api_key, upstream_model, body, **kwargs) -> (body, status, headers)."""
     candidates, chosen_id, canonical = resolve_candidates(session_id, body.get("model", ""), body)
     if not chosen_id or not candidates:
+        msg = "No available provider for this request" if no_provider_code == "no_provider" else "No available provider"
         return (
-            {"error": {"message": "No available provider for this request", "type": "api_error", "code": "no_provider"}},
+            {"error": {"message": msg, "type": "api_error", "code": no_provider_code}},
             503,
             {},
             None,
         )
-    stream = body.get("stream", False)
-    upstream_model = _upstream_model_part(canonical)
+    upstream_model = upstream_model_part(canonical)
     last_error = None
     last_status = 503
     for p in candidates:
@@ -81,12 +85,9 @@ async def _try_chat_completions(
         provider = _get_provider(pid)
         if not provider:
             continue
-        key_enc = provider.get("api_key_encrypted")
-        api_key = decrypt_api_key(key_enc)
+        api_key = decrypt_api_key(provider.get("api_key_encrypted"))
         endpoint = provider.get("endpoint", "")
-        result = await _adapter.call_chat_completions(
-            pid, endpoint, api_key, upstream_model, body, stream
-        )
+        result = await adapter_call(pid, endpoint, api_key, upstream_model, body)
         resp_body, status, out_headers = result[0], result[1], result[2]
         if status >= 400:
             mark_provider_unhealthy(pid)
@@ -95,9 +96,7 @@ async def _try_chat_completions(
             continue
         out_headers["X-Router-Provider"] = pid
         out_headers["X-Router-Upstream-Model"] = upstream_model
-        if isinstance(resp_body, dict) and "model" not in resp_body:
-            resp_body["model"] = canonical_model
-        elif isinstance(resp_body, dict):
+        if isinstance(resp_body, dict):
             resp_body["model"] = canonical_model
         return resp_body, status, out_headers, pid
     return (
@@ -106,6 +105,15 @@ async def _try_chat_completions(
         {},
         None,
     )
+
+
+async def _try_chat_completions(
+    body: dict, session_id: str, canonical_model: str
+) -> tuple[Any, int, dict[str, str], str | None]:
+    """Try candidates for chat; return (body_or_stream, status, headers, chosen_provider_id)."""
+    async def call_chat(pid: str, endpoint: str, api_key: str | None, um: str, b: dict) -> Any:
+        return await _adapter.call_chat_completions(pid, endpoint, api_key, um, b, b.get("stream", False))
+    return await _try_candidates(body, session_id, canonical_model, "no_provider", call_chat)
 
 
 def _apply_openai_headers(upstream_headers: dict[str, str], out: dict[str, str], elapsed_ms: int | None = None) -> None:
@@ -130,7 +138,7 @@ async def post_chat_completions(request: Request):
         )
     session_id = get_session_id(request)
     model = body.get("model", "")
-    canonical = _resolve_canonical_model(model)
+    canonical = resolve_canonical_model(model)
     t0 = time.perf_counter()
     result_body, status, headers, provider_id = await _try_chat_completions(body, session_id, canonical)
     elapsed_ms = int((time.perf_counter() - t0) * 1000) if status < 400 else None
@@ -151,43 +159,10 @@ async def post_chat_completions(request: Request):
 async def _try_embeddings(
     body: dict, session_id: str, canonical_model: str
 ) -> tuple[dict, int, dict[str, str], str | None]:
-    candidates, chosen_id, canonical = resolve_candidates(session_id, body.get("model", ""), body)
-    if not chosen_id or not candidates:
-        return (
-            {"error": {"message": "No available provider", "type": "api_error", "code": "no_provider"}},
-            503,
-            {},
-            None,
-        )
-    upstream_model = _upstream_model_part(canonical)
-    last_error = None
-    last_status = 503
-    for p in candidates:
-        pid = p["id"]
-        provider = _get_provider(pid)
-        if not provider:
-            continue
-        api_key = decrypt_api_key(provider.get("api_key_encrypted"))
-        result = await _adapter.call_embeddings(
-            pid, provider.get("endpoint", ""), api_key, upstream_model, body
-        )
-        resp_body, status, out_headers = result[0], result[1], result[2]
-        if status >= 400:
-            mark_provider_unhealthy(pid)
-            last_error = resp_body
-            last_status = status
-            continue
-        out_headers["X-Router-Provider"] = pid
-        out_headers["X-Router-Upstream-Model"] = upstream_model
-        if isinstance(resp_body, dict):
-            resp_body["model"] = canonical_model
-        return resp_body, status, out_headers, pid
-    return (
-        last_error or {"error": {"message": "All providers failed", "type": "api_error", "code": "failover_exhausted"}},
-        last_status,
-        {},
-        None,
-    )
+    """Try candidates for embeddings; return (body, status, headers, chosen_provider_id)."""
+    async def call_emb(pid: str, endpoint: str, api_key: str | None, um: str, b: dict) -> Any:
+        return await _adapter.call_embeddings(pid, endpoint, api_key, um, b)
+    return await _try_candidates(body, session_id, canonical_model, "no_provider", call_emb)
 
 
 @router.post("/embeddings")
@@ -202,7 +177,7 @@ async def post_embeddings(request: Request):
         )
     session_id = get_session_id(request)
     model = body.get("model", "")
-    canonical = _resolve_canonical_model(model)
+    canonical = resolve_canonical_model(model)
     t0 = time.perf_counter()
     result_body, status, headers, _ = await _try_embeddings(body, session_id, canonical)
     elapsed_ms = int((time.perf_counter() - t0) * 1000) if status < 400 else None

--- a/router/routing_engine.py
+++ b/router/routing_engine.py
@@ -1,6 +1,9 @@
 """
 Routing engine: provider order, capability gating, override, failover, model ID resolution.
 Plan 4.1–4.6. No request/usage logging to DB.
+
+Failover: failover_conditions in DB are persisted for API consistency and future use (e.g. Phase 2).
+This engine currently uses only in-memory health and providers.credit_threshold for failover.
 """
 
 import json
@@ -37,19 +40,19 @@ def _is_multimodal_request(body: dict[str, Any]) -> bool:
     return False
 
 
-def _resolve_canonical_model(request_model: str) -> str:
-    """Resolve alias to canonical id; otherwise return as-is."""
+def resolve_canonical_model(request_model: str) -> str:
+    """Public API: resolve alias to canonical id; otherwise return as-is."""
     return db.model_aliases_resolve(request_model) or request_model
 
 
-def _upstream_model_part(canonical_id: str) -> str:
-    """If canonical is provider+model return model part; else return canonical_id."""
+def upstream_model_part(canonical_id: str) -> str:
+    """Public API: if canonical is provider+model return model part; else return canonical_id."""
     if "+" in canonical_id:
         return canonical_id.split("+", 1)[1]
     return canonical_id
 
 
-def _providers_with_model(providers: list[dict], upstream_model: str) -> list[dict]:
+def _providers_with_model(providers: list[dict[str, Any]], upstream_model: str) -> list[dict[str, Any]]:
     """Filter to providers that list this upstream model (in their models JSON array)."""
     out = []
     for p in providers:
@@ -108,8 +111,8 @@ def resolve_candidates(
     Return (ordered_candidates, chosen_provider_id, canonical_model_id).
     chosen_provider_id may be None if no candidate; canonical_model_id is for response model echo.
     """
-    canonical = _resolve_canonical_model(request_model)
-    upstream_model = _upstream_model_part(canonical)
+    canonical = resolve_canonical_model(request_model)
+    upstream_model = upstream_model_part(canonical)
 
     ordered = _provider_order()
     with_model = _providers_with_model(ordered, upstream_model)
@@ -122,6 +125,7 @@ def resolve_candidates(
     capable = filter_by_capability(with_model, has_tools=has_tools, stream=stream, multimodal=multimodal)
     available = filter_available(capable)
 
+    # Override is honored only when the provider is in the available set.
     override_provider_id = db.agent_override_get(session_id)
     if override_provider_id:
         for p in available:

--- a/tests/unit/test_routing_engine.py
+++ b/tests/unit/test_routing_engine.py
@@ -34,21 +34,21 @@ def two_providers(clean_db_path):
 
 
 def test_resolve_canonical_model_passthrough(clean_db_path):
-    """_resolve_canonical_model returns request_model when no alias."""
-    assert re._resolve_canonical_model("gpt-4") == "gpt-4"
-    assert re._resolve_canonical_model("openai+gpt-4") == "openai+gpt-4"
+    """resolve_canonical_model returns request_model when no alias."""
+    assert re.resolve_canonical_model("gpt-4") == "gpt-4"
+    assert re.resolve_canonical_model("openai+gpt-4") == "openai+gpt-4"
 
 
 def test_resolve_canonical_model_alias(clean_db_path):
-    """_resolve_canonical_model resolves alias from DB."""
+    """resolve_canonical_model resolves alias from DB."""
     db.model_aliases_set("gpt", "openai+gpt-4")
-    assert re._resolve_canonical_model("gpt") == "openai+gpt-4"
+    assert re.resolve_canonical_model("gpt") == "openai+gpt-4"
 
 
 def test_upstream_model_part():
-    """_upstream_model_part returns model part after + or full id."""
-    assert re._upstream_model_part("openai+gpt-4") == "gpt-4"
-    assert re._upstream_model_part("gpt-4") == "gpt-4"
+    """upstream_model_part returns model part after + or full id."""
+    assert re.upstream_model_part("openai+gpt-4") == "gpt-4"
+    assert re.upstream_model_part("gpt-4") == "gpt-4"
 
 
 def test_filter_by_capability():


### PR DESCRIPTION
Group 4. #15 generic _try_candidates; #18 resolve_canonical_model/upstream_model_part public; #19 failover_conditions doc; #20 override comment. v0.1.5.

Made with [Cursor](https://cursor.com)